### PR TITLE
[canopen_ros2_control] Dependency fix

### DIFF
--- a/canopen_ros2_control/CMakeLists.txt
+++ b/canopen_ros2_control/CMakeLists.txt
@@ -18,6 +18,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gmock REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()

--- a/canopen_ros2_control/package.xml
+++ b/canopen_ros2_control/package.xml
@@ -11,14 +11,16 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rclcpp</depend>
-  <depend>rclcpp_lifecycle</depend>
-  <depend>hardware_interface</depend>
-  <depend>pluginlib</depend>
-  <depend>ros2_control_test_assets</depend>
   <depend>ament_cmake_gmock</depend>
   <depend>canopen_core</depend>
+  <depend>canopen_proxy_driver</depend>
+  <depend>hardware_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
   <depend>rclcpp_components</depend>
+  <depend>ros2_control_test_assets</depend>
+  <depend>std_srvs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
PR info:
- add `ament_cmake_gmock` as required dependency
- update `package.xml` 